### PR TITLE
Make query syntax compatible with /v2/alerts api

### DIFF
--- a/lambda/opsgenie-api/index.js
+++ b/lambda/opsgenie-api/index.js
@@ -52,7 +52,7 @@ function doGetRequest (path, context){
 }
 
 function listAlerts(event, context){
-    var path = listAlertsEndpoint + "?limit="+ event.limit +"&query=tags%3A" + encodeURIComponent(config.statusPageTag)+ "," +  encodeURIComponent(config.serviceNameTagPrefix + event.serviceName) ;
+    var path = listAlertsEndpoint + "?limit=" + event.limit + "&query=tag%3A%27" + encodeURIComponent(config.statusPageTag) + "%27%20tag%3A%27" + encodeURIComponent(config.serviceNameTagPrefix + event.serviceName) + "%27";
     if(event.createdBefore){
         path += "&query=createdBefore%3A" + event.createdBefore;
     }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -118,12 +118,12 @@ angular.module('myApp', ['infinite-scroll', 'cgBusy', 'ui.bootstrap', 'ui.router
                             alertsLock = false;
                         }else{
                             $scope.alerts = $scope.alerts || [];
-                            alertsSize = result.alerts.length;
+                            alertsSize = result.data.length;
                             for(var i=0; i<alertsSize; i++){
-                                var alert = result.alerts[i];
+                                var alert = result.data[i];
 
                                 var severity = getAlertsSeverity(alert.tags);
-                                var alertObj = {severity: severity, status: alert.status, message: alert.message, date: (Number(alert.createdAt)) / 1000000, createdAt: alert.createdAt, id: alert.id, isCollapsed: true};
+                                var alertObj = {severity: severity, status: alert.status, message: alert.message, date: alert.createdAt, createdAt: alert.createdAt, id: alert.id, isCollapsed: true};
                                 $scope.alerts.push(alertObj);
                                 if(i == 0){
                                     loadAlertNotes(0, alert.id);


### PR DESCRIPTION
`query=tags:tag1,tag2` no longer works, instead it's `query=tag:tag1 tag:tag2`. On top of that, if your tag contains a ':' character, you need to wrap it in quotes.

In case somebody defines the "statuspage" tag as "status:page" I've also wrapped quotes around that tag in the query string.

Also, the responses from the Lambda functions have changed, it's now `result.data` instead of `result.alerts`.